### PR TITLE
Adding Laravel Jetstream to Presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
 
 ### Presets
 
+- [Laravel Jetstream](https://jetstream.laravel.com/1.x/stacks/inertia.html) - Official application scaffolding within the Laravel Installer which provides the Tailwind CSS, Inertia.js and Vue.js stack.
 - [`use-preset/laravel-inertia`](https://github.com/use-preset/laravel-inertia) - One-command Laravel preset with Tailwind CSS, Inertia.js and Vue.js.
 - [`laravel-frontend-presets/inertiajs`](https://github.com/laravel-frontend-presets/inertiajs) - Laravel front-end preset for Inertia.js.
 - [Laravel Moonlight](https://github.com/TitasGailius/laravel-moonlight) - Laravel front-end preset with Tailwind CSS, Inertia.js and Vue.js.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@
 - [`laravel-frontend-presets/inertiajs`](https://github.com/laravel-frontend-presets/inertiajs) - Laravel front-end preset for Inertia.js.
 - [Laravel Moonlight](https://github.com/TitasGailius/laravel-moonlight) - Laravel front-end preset with Tailwind CSS, Inertia.js and Vue.js.
 - [Titanium](https://github.com/usetitanium/inertia) - Laravel front-end preset with Tailwind CSS, Inertia.js and Vue.js.
-- [Laravel Jetstream](https://jetstream.laravel.com/1.x/stacks/inertia.html) - Official application scaffolding within the Laravel Installer which provides the Tailwind CSS, Inertia.js and Vue.js stack.
+- [Laravel Jetstream](https://jetstream.laravel.com/1.x/stacks/inertia.html) - Laravel's official application scaffolding, with Tailwind CSS, Inertia.js and Vue.js.
 
 ### Packages
 

--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@
 
 ### Presets
 
-- [Laravel Jetstream](https://jetstream.laravel.com/1.x/stacks/inertia.html) - Official application scaffolding within the Laravel Installer which provides the Tailwind CSS, Inertia.js and Vue.js stack.
 - [`use-preset/laravel-inertia`](https://github.com/use-preset/laravel-inertia) - One-command Laravel preset with Tailwind CSS, Inertia.js and Vue.js.
 - [`laravel-frontend-presets/inertiajs`](https://github.com/laravel-frontend-presets/inertiajs) - Laravel front-end preset for Inertia.js.
 - [Laravel Moonlight](https://github.com/TitasGailius/laravel-moonlight) - Laravel front-end preset with Tailwind CSS, Inertia.js and Vue.js.
 - [Titanium](https://github.com/usetitanium/inertia) - Laravel front-end preset with Tailwind CSS, Inertia.js and Vue.js.
+- [Laravel Jetstream](https://jetstream.laravel.com/1.x/stacks/inertia.html) - Official application scaffolding within the Laravel Installer which provides the Tailwind CSS, Inertia.js and Vue.js stack.
 
 ### Packages
 


### PR DESCRIPTION
| Name                 | Link                 |
| -------------------- | -------------------- |
| Laravel Jetstream | https://jetstream.laravel.com/1.x/stacks/inertia.html |

The Inertia.js stack provided by Jetstream uses Vue.js as its templating language. Building an Inertia application is a lot like building a typical Vue application; however, you will use Laravel's router instead of Vue router. Inertia is a small library that allows you to render single-file Vue components from your Laravel backend by providing the name of the component and the data that should be hydrated into that component's "props".

In other words, this stack gives you the full power of Vue.js without the complexity of client-side routing. You get to use the standard Laravel router that you are used to. The Inertia stack is a great choice if you are comfortable with and enjoy using Vue.js as your templating language.

---

- [x] My item is in the right category
- [x] My item has been added to the bottom of the list
- [ ] My item's name and description respects the conventions of the list **[Needs review]**
- [ ] I have read and followed the [contributing guidelines](.github/CONTRIBUTING.md) **[Needs review]**
