### PR TITLE
add(presets): Breeze React

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@
 - [Laravel front-end preset](https://github.com/laravel-frontend-presets/inertiajs) - Laravel front-end preset for Inertia.js.
 - [Laravel Moonlight](https://github.com/TitasGailius/laravel-moonlight) - Laravel front-end preset with Tailwind CSS, Inertia.js and Vue.js.
 - [Titanium](https://github.com/usetitanium/inertia) - Laravel front-end preset with Tailwind CSS, Inertia.js and Vue.js.
-- [Laravel Breeze React](https://github.com/lucky-media/breeze-react) - Laravel Breeze fork with Tailwind CSS, Inertia.js and React
+- [Breeze React](https://github.com/lucky-media/breeze-react) - Laravel Breeze fork with Tailwind CSS, Inertia.js and React.
 
 ### Packages
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@
 - [Laravel front-end preset](https://github.com/laravel-frontend-presets/inertiajs) - Laravel front-end preset for Inertia.js.
 - [Laravel Moonlight](https://github.com/TitasGailius/laravel-moonlight) - Laravel front-end preset with Tailwind CSS, Inertia.js and Vue.js.
 - [Titanium](https://github.com/usetitanium/inertia) - Laravel front-end preset with Tailwind CSS, Inertia.js and Vue.js.
+- [Laravel Breeze React](https://github.com/lucky-media/breeze-react) - Laravel Breeze fork with Tailwind CSS, Inertia.js and React
 
 ### Packages
 


### PR DESCRIPTION
Our new package is a fork of Laravel Breeze, but adds support for React, by default it has only the Inertia views.

| Name                 | Link                 |
| -------------------- | -------------------- |
| Breeze React | https://github.com/lucky-media/breeze-react |

Laravel Breeze fork with Tailwind CSS, Inertia.js and React

---

- [x] My item is in the right category
- [x] My item has been added to the bottom of the list
- [x] My item's name and description respects the conventions of the list
- [x] I have read and followed the [contributing guidelines](.github/CONTRIBUTING.md)
